### PR TITLE
Players must sleep at night only!

### DIFF
--- a/Sleep Most/src/me/qintinator/sleepmost/eventlisteners/OnSleep.java
+++ b/Sleep Most/src/me/qintinator/sleepmost/eventlisteners/OnSleep.java
@@ -28,6 +28,12 @@ public class OnSleep implements Listener {
 		
 		if(main.getConfig().get("sleep.percentage-required") == null)
 			return;
+		
+		if(Bukkit.getWorlds().get(0).getTime() < 12300)
+			return;
+		
+		if(Bukkit.getWorlds().get(0).getTime() > 23850)
+			return;
 				
 		float percentageRequired = main.getConfig().getInt("sleep.percentage-required");
 		float onlinePlayers = Bukkit.getOnlinePlayers().size();


### PR DESCRIPTION
Before, players could skip the day even if it wasn't night. I thought it fair to limit the players to sleep and skip the day only at night.