### PR TITLE
Add api-version to plugin.yml

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,6 @@
 name: sleep-most
 version: 4.6.0
+api-version: 1.16
 main: me.mrgeneralq.sleepmost.Sleepmost
 authors: [MrGeneralQ, HorrendousEntity]
 commands:


### PR DESCRIPTION
This is a simple one-line fix that will get rid of the following warning message on Bukkit/Spigot/Paper:
```
[Server thread/WARN]: Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
[Server thread/WARN]: Legacy plugin sleep-most v4.6.0 does not specify an api-version.
```
I set the api-version to 1.16 since sleep-most's SpigotMC resource page lists 1.16 as the native version for the plugin, but it doesn't really matter. Here is the [documentation](https://www.spigotmc.org/wiki/plugin-yml/) for that attribute.