### PR TITLE
fix listener prio to avoid plugin conflicts.

### DIFF
--- a/src/me/mrgeneralq/sleepmost/eventlisteners/PlayerSleepEventListener.java
+++ b/src/me/mrgeneralq/sleepmost/eventlisteners/PlayerSleepEventListener.java
@@ -9,6 +9,7 @@ import me.mrgeneralq.sleepmost.statics.VersionController;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerBedLeaveEvent;
@@ -33,15 +34,11 @@ public class PlayerSleepEventListener implements Listener {
     }
 
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerSleep(PlayerBedEnterEvent e) {
 
         Player player = e.getPlayer();
         World world = player.getWorld();
-
-        if (e.isCancelled())
-            return;
-
 
         //used to calculate sleeping players different for lower versions
         if (VersionController.isOldVersion())


### PR DESCRIPTION
This is a Pull Request to avoid plugin conflicts for plugins using the PlayerEnterBedEvent.

This is caused by race conditions.
If a plugin cancels the event and has no priority set, a race condition takes place.

In this case bukkit decides which plugin gets the event first and the time till the event is handled as well. This can cause unexpected behaviour.

This PR fixes this by setting the priority to hightest which causes that sleep most will have the last word and will get an event which is already handelt by all other plugins. This makes it save to count the player as sleeping since no further changes to the event will most likely happen.

The ignoreCanceled flag makes some code obsolet so I removed it.