### PR TITLE
Custom Resource Pack Sound

### DIFF
--- a/src/main/java/me/mrgeneralq/sleepmost/exceptions/InvalidSleepSkipCauseOccurredException.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/exceptions/InvalidSleepSkipCauseOccurredException.java
@@ -1,0 +1,8 @@
+package me.mrgeneralq.sleepmost.exceptions;
+
+public class InvalidSleepSkipCauseOccurredException extends Exception {
+
+    public InvalidSleepSkipCauseOccurredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/me/mrgeneralq/sleepmost/flags/UseSkipSoundFlag.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/flags/UseSkipSoundFlag.java
@@ -1,0 +1,11 @@
+package me.mrgeneralq.sleepmost.flags;
+
+import me.mrgeneralq.sleepmost.flags.controllers.AbstractFlagController;
+import me.mrgeneralq.sleepmost.flags.types.BooleanFlag;
+
+public class UseSkipSoundFlag extends BooleanFlag {
+
+    public UseSkipSoundFlag(String flagKey, Boolean defaultValue, AbstractFlagController<Boolean> controller) {
+        super(flagKey, controller, defaultValue);
+    }
+}

--- a/src/main/java/me/mrgeneralq/sleepmost/flags/UseSoundNightSkippedFlag.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/flags/UseSoundNightSkippedFlag.java
@@ -3,9 +3,9 @@ package me.mrgeneralq.sleepmost.flags;
 import me.mrgeneralq.sleepmost.flags.controllers.AbstractFlagController;
 import me.mrgeneralq.sleepmost.flags.types.BooleanFlag;
 
-public class UseSoundNightSkippedFlag extends BooleanFlag
-{
+public class UseSoundNightSkippedFlag extends UseSkipSoundFlag {
+
     public UseSoundNightSkippedFlag(AbstractFlagController<Boolean> controller) {
-        super("use-sound-night-skipped", controller, false);
+        super("use-sound-night-skipped", false, controller);
     }
 }

--- a/src/main/java/me/mrgeneralq/sleepmost/flags/UseSoundStormSkippedFlag.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/flags/UseSoundStormSkippedFlag.java
@@ -3,9 +3,9 @@ package me.mrgeneralq.sleepmost.flags;
 import me.mrgeneralq.sleepmost.flags.controllers.AbstractFlagController;
 import me.mrgeneralq.sleepmost.flags.types.BooleanFlag;
 
-public class UseSoundStormSkippedFlag extends BooleanFlag
-{
+public class UseSoundStormSkippedFlag extends UseSkipSoundFlag {
+
     public UseSoundStormSkippedFlag(AbstractFlagController<Boolean> controller) {
-        super("use-sound-storm-skipped", controller, false);
+        super("use-sound-storm-skipped", false, controller);
     }
 }

--- a/src/main/java/me/mrgeneralq/sleepmost/flags/types/AbstractFlag.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/flags/types/AbstractFlag.java
@@ -39,8 +39,11 @@ public abstract class AbstractFlag<V> implements ISleepFlag<V>
     }
 
     @Override
-    public V getValueAt(World world)
-    {
+    public V getValueAt(World world) {
+        if (this.controller == null) {
+            return this.defaultValue;
+        }
+
         return this.controller.getValueAt(world);
     }
 

--- a/src/main/java/me/mrgeneralq/sleepmost/interfaces/IConfigService.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/interfaces/IConfigService.java
@@ -1,6 +1,5 @@
 package me.mrgeneralq.sleepmost.interfaces;
 
-import org.bukkit.Sound;
 import org.bukkit.World;
 
 import java.util.Set;
@@ -15,9 +14,7 @@ public interface IConfigService {
     boolean getTitleStormSkippedEnabled();
     String getTitleStormSkippedTitle();
     String getTitleStormSkippedSubTitle();
-    boolean getSoundNightSkippedEnabled();
-    Sound getSoundNightSkippedSound();
-    boolean getSoundStormSkippedEnabled();
-    Sound getSoundStormSkippedSound();
+    String getNightSkippedSound();
+    String getStormSkippedSound();
     Set<World> getEnabledWorlds();
 }

--- a/src/main/java/me/mrgeneralq/sleepmost/services/ConfigService.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/services/ConfigService.java
@@ -61,40 +61,14 @@ public class ConfigService implements IConfigService {
         return colorize(main.getConfig().getString("titles.storm-skipped.subtitle"));
     }
 
-
     @Override
-    public boolean getSoundNightSkippedEnabled(){
-        return main.getConfig().getBoolean("sounds.night-skipped.enabled");
+    public String getNightSkippedSound(){
+        return main.getConfig().getString("sounds.night-skipped.sound");
     }
 
     @Override
-    public Sound getSoundNightSkippedSound(){
-
-        try{
-            String soundName = main.getConfig().getString("sounds.night-skipped.sound");
-            return Sound.valueOf(soundName);
-        }catch(Exception ex){
-            return null;
-        }
-
-    }
-
-    @Override
-    public boolean getSoundStormSkippedEnabled(){
-        return main.getConfig().getBoolean("sounds.storm-skipped.enabled");
-    }
-
-
-    @Override
-    public Sound getSoundStormSkippedSound(){
-        try{
-            String soundName = main.getConfig().getString("sounds.storm-skipped.sound");
-            return Sound.valueOf(soundName);
-        }
-        catch(Exception ex)
-        {
-            return null;
-        }
+    public String getStormSkippedSound(){
+        return main.getConfig().getString("sounds.storm-skipped.sound");
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,9 +69,9 @@ titles:
 # Add sound effects after skipping the night or storm
 sounds:
   night-skipped:
-    sound: UI_TOAST_CHALLENGE_COMPLETE
+    sound: ui.toast.challenge_complete
   storm-skipped:
-    sound: ENTITY_WITHER_SPAWN
+    sound: entity.wither.spawn
 
 
 # specify the time which the world will be set after reset


### PR DESCRIPTION
Solving issue #102 - Play Custom Sounds From Resource Packs

### Changes
- SleepSkipEventListener changed to handle custom resource pack sounds
    - Added an Exception throw for when skip sound couldn't be found because of no valid SleepSkipCause
    - Added method SleepSkipEventListener#getSkipSound, see it's documentation
    - Added method SleepSkipEventListener#getSkipSoundEnabledFlag, see it's documentation
    - Changed method SleepSkipEventListener#sendSkipSound
- Removed import '`org.bukkit.Sound`' in IConfigService
- Removed method IConfigService#getSoundStormSkippedEnabled
- Removed method IConfigService#getSoundNightSkippedEnabled
- Renamed method IConfigService#getSoundStormSkippedSound to IConfigService#getStormSkippedSound
- Renamed method IConfigService#getSoundNightSkippedSound to IConfigService#getNightSkippedSound
- Changed method return type from Sound to String for IConfigService#getNightSkippedSound
- Changed method return type from Sound to String for IConfigService#getStormSkippedSound
- Made appropriate changes in ConfigService after changing IConfigService
- Added new flag, UseSkipSoundFlag - Class extended by UseSoundNightSkippedFlag and UseSoundStormSkippedFlag
- Changed method AbstractFlag#getValueAt, returning default value if controller is null
- Added new Exception class, InvalidSleepSkipCauseOccurredException
- Updated default config.yml values to match the new code