### PR TITLE
clock animation include flag mapped to title instead

### DIFF
--- a/src/main/java/me/mrgeneralq/sleepmost/runnables/NightcycleAnimationTask.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/runnables/NightcycleAnimationTask.java
@@ -51,7 +51,7 @@ public class NightcycleAnimationTask extends BukkitRunnable {
 
             if(this.flagsRepository.getClockAnimationFlag().getValueAt(world) && ServerVersion.CURRENT_VERSION.supportsTitles()){
 
-                List<Player> playerList = (flagsRepository.getNonSleepingTitleFlag().getValueAt(world) ?
+                List<Player> playerList = (flagsRepository.getNonSleepingClockAnimationFlag().getValueAt(world) ?
                         world.getPlayers():
                         peopleWhoSlept.stream().filter(OfflinePlayer::isOnline).map(OfflinePlayer::getPlayer).collect(Collectors.toList()));
 
@@ -69,7 +69,7 @@ public class NightcycleAnimationTask extends BukkitRunnable {
 
             if(this.flagsRepository.getClockAnimationFlag().getValueAt(world) && ServerVersion.CURRENT_VERSION.supportsTitles()){
 
-                List<Player> playerList = (flagsRepository.getNonSleepingTitleFlag().getValueAt(world) ?
+                List<Player> playerList = (flagsRepository.getNonSleepingClockAnimationFlag().getValueAt(world) ?
                         world.getPlayers():
                         peopleWhoSlept.stream().filter(OfflinePlayer::isOnline).map(OfflinePlayer::getPlayer).collect(Collectors.toList()));
 


### PR DESCRIPTION
- when the clock animation was enabled, it would do nothing as it was bound to the non-sleeping-title flag instead