### PR TITLE
Fixed some things

### DIFF
--- a/src/main/java/me/mrgeneralq/sleepmost/Sleepmost.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/Sleepmost.java
@@ -45,13 +45,14 @@ public class Sleepmost extends JavaPlugin {
 		pm.registerEvents(new PlayerQuitEventListener(bootstrapper.getCooldownService(), bootstrapper.getSleepService(), bootstrapper.getBossBarService()), this);
 
 		if(ServerVersion.CURRENT_VERSION.hasTimeSkipEvent())
-		pm.registerEvents(new SleepSkipEventListener(bootstrapper.getMessageService(), bootstrapper.getConfigService(), bootstrapper.getSleepService(), bootstrapper.getFlagsRepository(), bootstrapper.getBossBarService()), this);
+		pm.registerEvents(new TimeSkipEventListener(bootstrapper.getSleepService()), this);
 
 		pm.registerEvents(new EntityTargetLivingEntityEventListener(bootstrapper.getFlagsRepository()), this);
 		pm.registerEvents(new PlayerWorldChangeEventListener(bootstrapper.getSleepService(), bootstrapper.getMessageService(), bootstrapper.getBossBarService()), this);
 		pm.registerEvents(new PlayerJoinEventListener(this, bootstrapper.getUpdateService(), bootstrapper.getMessageService(), bootstrapper.getBossBarService()), this);
 		pm.registerEvents(new EntitySpawnEventListener(bootstrapper.getFlagsRepository()), this);
 		pm.registerEvents(new TimeSkipEventListener(bootstrapper.getSleepService()), this);
+		pm.registerEvents(new SleepSkipEventListener(bootstrapper.getMessageService(), bootstrapper.getConfigService(), bootstrapper.getSleepService(), bootstrapper.getFlagsRepository(), bootstrapper.getBossBarService()), this);
 		pm.registerEvents(new WorldChangeEventListener(bootstrapper.getSleepService()), this);
 		pm.registerEvents(new PlayerBedLeaveEventListener(bootstrapper.getSleepService()), this);
 		pm.registerEvents(new WorldLoadEventListener(bootstrapper.getBossBarService()),this);

--- a/src/main/java/me/mrgeneralq/sleepmost/Sleepmost.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/Sleepmost.java
@@ -17,11 +17,12 @@ import me.mrgeneralq.sleepmost.statics.Bootstrapper;
 
 public class Sleepmost extends JavaPlugin {
 
+	private static Sleepmost instance;
 	private Bootstrapper bootstrapper;
 
 	@Override
 	public void onEnable() {
-
+                instance = this;
 		saveDefaultConfig();
 		
 		//init metrics
@@ -62,6 +63,10 @@ public class Sleepmost extends JavaPlugin {
 		runTimers(bootstrapper.getSleepService());
 
 	}
+	
+        public static Sleepmost getInstance() {
+                return instance;
+        }
 
 	private void runTimers(ISleepService sleepService){
 		new Heartbeat(sleepService).runTaskTimer(this, 20,20);

--- a/src/main/java/me/mrgeneralq/sleepmost/eventlisteners/SleepSkipEventListener.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/eventlisteners/SleepSkipEventListener.java
@@ -2,6 +2,7 @@ package me.mrgeneralq.sleepmost.eventlisteners;
 
 import static me.mrgeneralq.sleepmost.enums.SleepSkipCause.NIGHT_TIME;
 import me.mrgeneralq.sleepmost.exceptions.InvalidSleepSkipCauseOccurredException;
+import me.mrgeneralq.sleepmost.Sleepmost;
 import me.mrgeneralq.sleepmost.flags.SkipSoundFlag;
 import me.mrgeneralq.sleepmost.flags.UseSkipSoundFlag;
 import me.mrgeneralq.sleepmost.interfaces.*;
@@ -11,6 +12,7 @@ import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import me.mrgeneralq.sleepmost.enums.SleepSkipCause;
 import me.mrgeneralq.sleepmost.events.SleepSkipEvent;
@@ -54,9 +56,15 @@ public class SleepSkipEventListener implements Listener {
         resetPhantomCounter(world);
         sendSkipSound(world, e);
 
-        if (ServerVersion.CURRENT_VERSION.supportsTitles())
-            sendSkipTitle(world, e);
-
+        if (ServerVersion.CURRENT_VERSION.supportsTitles()) {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    sendSkipTitle(world, e);
+                }
+            }.runTaskLater(Sleepmost.getInstance(), 5);
+        }
+        
         boolean shouldHeal = flagsRepository.getHealFlag().getValueAt(world);
         boolean shouldFeed = flagsRepository.getFeedFlag().getValueAt(world);
 

--- a/src/main/java/me/mrgeneralq/sleepmost/statics/ServerVersion.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/statics/ServerVersion.java
@@ -29,7 +29,7 @@ public enum ServerVersion
     static {
         CURRENT_VERSION = computeServerVersion();
         forVersionsFrom(V1_16, version -> version.supportsHexColors = true);
-        forVersionsFrom(V1_14, version -> version.supportsTitles = true);
+        forVersionsFrom(V1_12, version -> version.supportsTitles = true);
         forVersionsUntil(V1_9, version -> version.maxHPHealer = MaxHPHealer.LEGACY_HEALER);
         forVersionsFrom(V1_9, version -> version.maxHPHealer = MaxHPHealer.UPDATED_HEALER);
         forVersionsFrom(V1_15, version -> version.hasTimeSkipEvent = true);


### PR DESCRIPTION
Fixed:

- TimeSkipEventListener swapped with SleepSkipEventListener. Versions pre 1.15 were not handling  SleepSkipEventListener so the boss bar didn't dissapear, title didn't work, heal/hunger neither...
- Player#sendTitle() is available from 1.12, not 1.14.
- night-skipped and storm-skipped titles were not working if the clock counter was enabled, since it was shown before the clock counter title stopped, so it was then overwritten. I've added a 5 ticks delay to show the skipped titles after SleepSkipEventEvent.