### PR TITLE
fixed time cycle bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ bin/*
 
 # Maven
 target/
+
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.mrgeneralq</groupId>
     <artifactId>sleep-most</artifactId>
-    <version>5.1.2</version>
+    <version>5.1.3</version>
     <name>SleepMost</name>
 
     <properties>

--- a/src/main/java/me/mrgeneralq/sleepmost/Sleepmost.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/Sleepmost.java
@@ -98,7 +98,7 @@ public class Sleepmost extends JavaPlugin {
 		for(World world: Bukkit.getWorlds()){
 			this.bootstrapper.getSleepMostWorldService().registerWorld(world);
 
-			if(ServerVersion.CURRENT_VERSION.supportsGameRules())
+			if(ServerVersion.CURRENT_VERSION.supportsGameRules() && this.bootstrapper.getSleepService().isEnabledAt(world))
 			world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, true);
 		}
 	}


### PR DESCRIPTION
With the 5.1+ release, when the server is starting, all worlds (including lobbies) where time was frozen and sleep most not enabled would be forced back into starting to do the Time cycle again.

This update is highly recommended for any multi world servers using lobbies.