### PR TITLE
Improve dynamic nightcycle animation speed calculation

### DIFF
--- a/src/main/java/me/mrgeneralq/sleepmost/runnables/NightcycleAnimationTask.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/runnables/NightcycleAnimationTask.java
@@ -46,18 +46,23 @@ public class NightcycleAnimationTask extends BukkitRunnable {
     @Override
     public void run() {
         //85 by default
-        int calculatedSpeed = configService.getNightcycleAnimationSpeed();
+        final int baseSpeed = configService.getNightcycleAnimationSpeed();
+        int calculatedSpeed = baseSpeed;
 
         if(this.flagsRepository.getDynamicAnimationSpeedFlag().getValueAt(world)){
 
             int sleepingPlayers = this.sleepService.getSleepersAmount(world);
+            int minSleepingPlayers = this.sleepService.getRequiredSleepersCount(world);
             int totalPlayers = world.getPlayers().size();
-            double sleepRation = (double) sleepingPlayers / (double)totalPlayers;
 
-            int maxSpeed = 150;
-            int minSpeed = 30;
+            int numerator = Math.max(sleepingPlayers - minSleepingPlayers, 0);
+            int denominator = Math.max(totalPlayers - minSleepingPlayers, 1);
+            double additionalPlayersRatio = (double)numerator / (double)denominator;
 
-            calculatedSpeed = Math.min((int) Math.round((sleepRation * (maxSpeed - minSpeed)) + minSpeed), maxSpeed);
+            int maxSpeed = baseSpeed * 2;
+            int minSpeed = baseSpeed;
+
+            calculatedSpeed = Math.min((int) Math.round((additionalPlayersRatio * (maxSpeed - minSpeed)) + minSpeed), maxSpeed);
 
         }
         world.setTime(world.getTime() + calculatedSpeed);


### PR DESCRIPTION
This changes two things:
* Instead of the dynamic nightcycle animation speed having hard-coded min- and max-values, this uses the night cycle animation speed specified *in the config file* as the minimum and twice that value as the maximum.
* When the minimum required number of players (`SleepService.getRequiredSleepersCount()`) are sleeping, the speed starts off at the minimum.  
For every additional sleeper, the speed increases. Up to the maximum (2x) when all players on the server are sleeping.

### Example
`nightcycle-animation-speed`: **`85`**
`players-required`: **`2`**

Sleeping | `additionalPlayersRatio` | `calculatedSpeed`
:-: | --: | --:
2/5 | 0.00 | 85
3/5 | 0.33 | 113
4/5 | 0.66 | 142
5/5 | 1.00 | 170

---

This new calculation has the nice side effect that enabling `dynamic-animation-speed` doesn't change anything, as long as only the minimum required number of players are sleeping.
In particular, when only one players is on the server and sleeping, the speed also stays at the minimum value.

Another possible improvement would be to make the factor for the maximum value configurable by the user, of course.