### PR TITLE
Make maximum dynamic nightcycle animation speed configurable

### DIFF
--- a/src/main/java/me/mrgeneralq/sleepmost/interfaces/IConfigService.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/interfaces/IConfigService.java
@@ -12,6 +12,7 @@ public interface IConfigService {
     boolean debugModeEnabled();
 
     int getNightcycleAnimationSpeed();
+    int getNightcycleAnimationSpeedMax();
     int getNightStartTime();
     int getNightStopTime();
 }

--- a/src/main/java/me/mrgeneralq/sleepmost/runnables/NightcycleAnimationTask.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/runnables/NightcycleAnimationTask.java
@@ -47,6 +47,7 @@ public class NightcycleAnimationTask extends BukkitRunnable {
     public void run() {
         //85 by default
         final int baseSpeed = configService.getNightcycleAnimationSpeed();
+        final int maxSpeed = configService.getNightcycleAnimationSpeedMax();
         int calculatedSpeed = baseSpeed;
 
         if(this.flagsRepository.getDynamicAnimationSpeedFlag().getValueAt(world)){
@@ -59,7 +60,6 @@ public class NightcycleAnimationTask extends BukkitRunnable {
             int denominator = Math.max(totalPlayers - minSleepingPlayers, 1);
             double additionalPlayersRatio = (double)numerator / (double)denominator;
 
-            int maxSpeed = baseSpeed * 2;
             int minSpeed = baseSpeed;
 
             calculatedSpeed = Math.min((int) Math.round((additionalPlayersRatio * (maxSpeed - minSpeed)) + minSpeed), maxSpeed);

--- a/src/main/java/me/mrgeneralq/sleepmost/services/ConfigService.java
+++ b/src/main/java/me/mrgeneralq/sleepmost/services/ConfigService.java
@@ -51,6 +51,11 @@ public class ConfigService implements IConfigService {
     }
 
     @Override
+    public int getNightcycleAnimationSpeedMax() {
+        return main.getConfig().getInt("nightcycle-animation-speed-max");
+    }
+
+    @Override
     public int getNightStartTime() {
         return main.getConfig().getInt("time.start-time");
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,7 @@ update-checker-enabled: true
 # specify the speed/ticks for the animation
 # DEFAULT: 85 (recommended)
 nightcycle-animation-speed: 85
+nightcycle-animation-speed-max: 170
 
 
 sleep:


### PR DESCRIPTION
Building on #190, this makes the maximum animation speed (which has been hard-coded `minSpeed * 2.0` thus far) also configurable by adding a global setting **`nightcycle-animation-speed-max`**.

The default value is still `170` (twice default minimum speed).

---

Is there already a mechanism to patch existing user config files and add the new settings?

Please feel free to edit my branch/PR if you want :)