### PR TITLE
5.8.0: Paper 26.2 build workflow + smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,149 @@
+name: Build
+
+on:
+  push:
+    branches: ["feature/**", "dubsector/**"]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      mc_version: ${{ steps.mcver.outputs.mc_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Build
+        run: mvn clean package -pl paper -am -B
+
+      - name: Get version
+        id: ver
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+
+      - name: Extract target Paper version
+        id: mcver
+        run: |
+          MC_VERSION=$(python3 -c "import re; c=open('paper/pom.xml').read(); m=re.search(r'<artifactId>paper-api</artifactId>\s*<version>([0-9]+\.[0-9]+)', c); print(m.group(1) if m else '')")
+          echo "mc_version=${MC_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Target Paper version: ${MC_VERSION}"
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: SleepMost
+          path: target/SleepMost-*.jar
+
+  paper-smoke-test:
+    name: Paper Smoke Test
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      actions: write
+    steps:
+      - name: Download built JAR
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: SleepMost
+          path: plugin-jar/
+
+      - name: Resolve latest Paper build
+        id: paper
+        env:
+          MC_VERSION: ${{ needs.build.outputs.mc_version }}
+        run: |
+          curl -fsSL "https://fill.papermc.io/v3/projects/paper/versions/${MC_VERSION}/builds" -o /tmp/paper-builds.json
+          BUILD=$(python3 -c "import json; builds=json.load(open('/tmp/paper-builds.json')); stable=[b for b in builds if b.get('channel','')=='STABLE']; chosen=(stable or builds)[0]; print(chosen['id'])")
+          JAR_NAME=$(python3 -c "import json; builds=json.load(open('/tmp/paper-builds.json')); stable=[b for b in builds if b.get('channel','')=='STABLE']; chosen=(stable or builds)[0]; print(chosen['downloads']['server:default']['name'])")
+          JAR_URL=$(python3 -c "import json; builds=json.load(open('/tmp/paper-builds.json')); stable=[b for b in builds if b.get('channel','')=='STABLE']; chosen=(stable or builds)[0]; print(chosen['downloads']['server:default']['url'])")
+          echo "build=${BUILD}"       >> "$GITHUB_OUTPUT"
+          echo "jar_name=${JAR_NAME}" >> "$GITHUB_OUTPUT"
+          echo "jar_url=${JAR_URL}"   >> "$GITHUB_OUTPUT"
+          echo "Resolved: Paper ${MC_VERSION} build ${BUILD} (${JAR_NAME})"
+
+      - name: Download Paper server JAR
+        env:
+          JAR_URL: ${{ steps.paper.outputs.jar_url }}
+        run: |
+          mkdir -p smoke-server/plugins
+          curl -fsSL "$JAR_URL" -o smoke-server/paper.jar
+
+      - name: Detect required Java version
+        id: java_ver
+        env:
+          MC_VERSION: ${{ needs.build.outputs.mc_version }}
+        run: |
+          REQUIRED=$(curl -fsSL "https://fill.papermc.io/v3/projects/paper/versions/${MC_VERSION}" | python3 -c "import sys,json; print(json.load(sys.stdin)['version']['java']['version']['minimum'])")
+          echo "MC ${MC_VERSION} -> Java ${REQUIRED}"
+          echo "version=${REQUIRED}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up required JDK
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          java-version: ${{ steps.java_ver.outputs.version }}
+          distribution: 'temurin'
+
+      - name: Copy plugin JAR
+        run: cp plugin-jar/SleepMost-*.jar smoke-server/plugins/SleepMost.jar
+
+      - name: Configure server
+        run: |
+          echo "eula=true" > smoke-server/eula.txt
+          printf '%s\n' "online-mode=false" "level-type=flat" "generate-structures=false" "max-players=0" > smoke-server/server.properties
+
+      - name: Run server and wait for ready
+        run: |
+          cd smoke-server
+          java -Xms512m -Xmx1g -jar paper.jar --nogui > server.log 2>&1 &
+          SERVER_PID=$!
+          ELAPSED=0
+          while [ $ELAPSED -lt 120 ]; do
+            sleep 2; ELAPSED=$((ELAPSED + 2))
+            if grep -q "Done (" server.log 2>/dev/null; then
+              echo "Server ready after ${ELAPSED}s"; break
+            fi
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "Server process exited after ${ELAPSED}s"; break
+            fi
+          done
+          kill $SERVER_PID 2>/dev/null || true
+          wait $SERVER_PID 2>/dev/null || true
+
+      - name: Assert no SleepMost errors
+        run: |
+          LOG=smoke-server/server.log
+          PATTERN='(sleep-most|sleepmost)'
+          if grep -qiE "SEVERE.*${PATTERN}|Could not load.*${PATTERN}|Error.*${PATTERN}|${PATTERN}.*FAILED" "$LOG"; then
+            echo "::error::SleepMost logged errors on Paper startup:"
+            grep -iE "SEVERE.*${PATTERN}|Could not load.*${PATTERN}|Error.*${PATTERN}|${PATTERN}.*FAILED" "$LOG"
+            exit 1
+          fi
+          if ! grep -q "Done (" "$LOG"; then
+            cat "$LOG"
+            echo "::error::Server did not reach ready state"
+            exit 1
+          fi
+          echo "Paper smoke test passed"
+
+      - name: Upload server log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: paper-smoke-log
+          path: smoke-server/server.log
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK 25
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -93,7 +93,7 @@ jobs:
           echo "version=${REQUIRED}" >> "$GITHUB_OUTPUT"
 
       - name: Set up required JDK
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: ${{ steps.java_ver.outputs.version }}
           distribution: 'temurin'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: zizmor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          args: --format sarif

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.mrgeneralq</groupId>
         <artifactId>sleep-most</artifactId>
-        <version>5.8.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.mrgeneralq</groupId>
         <artifactId>sleep-most</artifactId>
-        <version>5.7.0</version>
+        <version>5.8.0</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: sleep-most
 api-version: 1.13
 version: ${project.version}
 main: me.mrgeneralq.sleepmost.core.Sleepmost
-authors: [MrGeneralQ, LesleyXYZ, HorrendousEntity]
+authors: [MrGeneralQ, LesleyXYZ, HorrendousEntity, dubsector]
 commands:
   sleepmost:
     usage: /sleepmost

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.mrgeneralq</groupId>
         <artifactId>sleep-most</artifactId>
-        <version>5.7.0</version>
+        <version>5.8.0</version>
     </parent>
     <artifactId>paper</artifactId>
 

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.mrgeneralq</groupId>
         <artifactId>sleep-most</artifactId>
-        <version>5.8.0</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>paper</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.mrgeneralq</groupId>
     <artifactId>sleep-most</artifactId>
-    <version>5.7.0</version>
+    <version>5.8.0</version>
     <packaging>pom</packaging>
     <name>SleepMost</name>
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.mrgeneralq</groupId>
     <artifactId>sleep-most</artifactId>
-    <version>5.8.0</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <name>SleepMost</name>
     <modules>
@@ -14,6 +14,8 @@
         <module>spigot</module>
     </modules>
     <properties>
+        <!-- Single source of truth for the plugin version; bump this to release. -->
+        <revision>5.8.0</revision>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.mrgeneralq</groupId>
         <artifactId>sleep-most</artifactId>
-        <version>5.8.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spigot</artifactId>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.mrgeneralq</groupId>
         <artifactId>sleep-most</artifactId>
-        <version>5.7.0</version>
+        <version>5.8.0</version>
     </parent>
 
     <artifactId>spigot</artifactId>


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds the paper module and boots a real Paper server against the built jar to verify it loads cleanly before anything ships — no auto-published release, just build + verify
- Centralizes the plugin version into a single `revision` property in root `pom.xml` (was previously hardcoded in 4 places: root pom + each module's parent version) so future version bumps are a one-line change
- Bumps version to 5.8.0
- Adds dubsector to `authors:` in plugin.yml

## Test plan
- [x] `Build` workflow: builds the paper module on JDK 25, uploads `SleepMost-5.8.0.jar`
- [x] `Paper Smoke Test`: resolves the matching Paper 26.2 build, boots it with the plugin installed, asserts no plugin-related errors and reaches ready state
- [x] `zizmor` workflow lint passes on the new workflow files
- [x] Verified packaged `plugin.yml` shows `version: 5.8.0` and updated authors list