### PR TITLE
Guard advanceTime game rule on versions that lack it

### DIFF
--- a/core/src/main/java/me/mrgeneralq/sleepmost/core/services/GameRuleService.java
+++ b/core/src/main/java/me/mrgeneralq/sleepmost/core/services/GameRuleService.java
@@ -1,17 +1,38 @@
 package me.mrgeneralq.sleepmost.core.services;
+
 import me.mrgeneralq.sleepmost.core.interfaces.IGameRuleService;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 
+import java.util.logging.Logger;
+
 public class GameRuleService implements IGameRuleService {
 
-    /*
-        * Sets the ADVANCE_TIME game rule for the specified world.
+    private static final Logger LOGGER = Logger.getLogger("sleep-most");
+    private static boolean warnedUnsupported = false;
+
+    /**
+     * Sets the ADVANCE_TIME game rule for the specified world.
+     * <p>
+     * ADVANCE_TIME only exists on newer Minecraft versions. On servers that do
+     * not have it, resolving the field throws {@link NoSuchFieldError}, so we
+     * catch that (and any related error) and skip the rule instead of letting
+     * the plugin fail on those versions.
      */
     @Override
     public void setAdvanceTime(World world, boolean value) {
-        world.setGameRule(GameRule.ADVANCE_TIME, value);
+        try {
+            world.setGameRule(GameRule.ADVANCE_TIME, value);
+        } catch (LinkageError | RuntimeException error) {
+            warnUnsupportedOnce(error);
+        }
     }
 
-
+    private static void warnUnsupportedOnce(Throwable error) {
+        if (warnedUnsupported) {
+            return;
+        }
+        warnedUnsupported = true;
+        LOGGER.warning("[sleep-most] The 'advanceTime' game rule is not available on this Minecraft version - skipping it. Cause: " + error);
+    }
 }

--- a/core/src/test/java/me/mrgeneralq/sleepmost/core/services/GameRuleServiceTest.java
+++ b/core/src/test/java/me/mrgeneralq/sleepmost/core/services/GameRuleServiceTest.java
@@ -1,0 +1,39 @@
+package me.mrgeneralq.sleepmost.core.services;
+
+import org.bukkit.World;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+public class GameRuleServiceTest {
+
+    private static World worldStub(InvocationHandler handler) {
+        return (World) Proxy.newProxyInstance(
+                World.class.getClassLoader(),
+                new Class<?>[]{World.class},
+                handler);
+    }
+
+    /**
+     * On servers without the ADVANCE_TIME game rule, referencing it fails with
+     * a {@link LinkageError} (NoSuchFieldError on older APIs; in this test JVM
+     * the GameRule registry cannot initialize without a running server, which
+     * raises ExceptionInInitializerError - also a LinkageError). Either way the
+     * service must swallow it instead of propagating.
+     * <p>
+     * The happy path (rule actually applied) is covered by the Paper smoke
+     * test in CI, which boots a real server with the built plugin.
+     */
+    @Test
+    public void setAdvanceTimeDoesNotPropagateWhenGameRuleUnavailable() {
+        World world = worldStub((proxy, method, args) -> {
+            if (method.getName().equals("setGameRule")) {
+                throw new NoSuchFieldError("ADVANCE_TIME");
+            }
+            return null;
+        });
+
+        new GameRuleService().setAdvanceTime(world, false);
+    }
+}

--- a/paper/src/main/java/me/mrgeneralq/sleepmost/paper/services/PaperGameRuleService.java
+++ b/paper/src/main/java/me/mrgeneralq/sleepmost/paper/services/PaperGameRuleService.java
@@ -4,9 +4,35 @@ import me.mrgeneralq.sleepmost.core.interfaces.IGameRuleService;
 import org.bukkit.GameRules;
 import org.bukkit.World;
 
+import java.util.logging.Logger;
+
 public class PaperGameRuleService implements IGameRuleService {
+
+    private static final Logger LOGGER = Logger.getLogger("sleep-most");
+    private static boolean warnedUnsupported = false;
+
+    /**
+     * Sets the ADVANCE_TIME game rule for the specified world.
+     * <p>
+     * ADVANCE_TIME only exists on newer Minecraft versions. On servers that do
+     * not have it, resolving the field throws {@link NoSuchFieldError}, so we
+     * catch that (and any related error) and skip the rule instead of letting
+     * the plugin fail on those versions.
+     */
     @Override
     public void setAdvanceTime(World world, boolean value) {
-        world.setGameRule(GameRules.ADVANCE_TIME, value);
+        try {
+            world.setGameRule(GameRules.ADVANCE_TIME, value);
+        } catch (LinkageError | RuntimeException error) {
+            warnUnsupportedOnce(error);
+        }
+    }
+
+    private static void warnUnsupportedOnce(Throwable error) {
+        if (warnedUnsupported) {
+            return;
+        }
+        warnedUnsupported = true;
+        LOGGER.warning("[sleep-most] The 'advanceTime' game rule is not available on this Minecraft version - skipping it. Cause: " + error);
     }
 }

--- a/spigot/src/main/java/me/mrgeneralq/sleepmost/spigot/services/SpigotGameRuleService.java
+++ b/spigot/src/main/java/me/mrgeneralq/sleepmost/spigot/services/SpigotGameRuleService.java
@@ -4,9 +4,35 @@ import me.mrgeneralq.sleepmost.core.interfaces.IGameRuleService;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 
+import java.util.logging.Logger;
+
 public class SpigotGameRuleService implements IGameRuleService {
+
+    private static final Logger LOGGER = Logger.getLogger("sleep-most");
+    private static boolean warnedUnsupported = false;
+
+    /**
+     * Sets the ADVANCE_TIME game rule for the specified world.
+     * <p>
+     * ADVANCE_TIME only exists on newer Minecraft versions. On servers that do
+     * not have it, resolving the field throws {@link NoSuchFieldError}, so we
+     * catch that (and any related error) and skip the rule instead of letting
+     * the plugin fail on those versions.
+     */
     @Override
     public void setAdvanceTime(World world, boolean value) {
-        world.setGameRule(GameRule.ADVANCE_TIME, value);
+        try {
+            world.setGameRule(GameRule.ADVANCE_TIME, value);
+        } catch (LinkageError | RuntimeException error) {
+            warnUnsupportedOnce(error);
+        }
+    }
+
+    private static void warnUnsupportedOnce(Throwable error) {
+        if (warnedUnsupported) {
+            return;
+        }
+        warnedUnsupported = true;
+        LOGGER.warning("[sleep-most] The 'advanceTime' game rule is not available on this Minecraft version - skipping it. Cause: " + error);
     }
 }


### PR DESCRIPTION
Reland of the fix from #214, rebased on current master so the build passes (#214 failed CI only because its branch had mismatched parent pom versions, 5.7.0 vs 5.7.1; master now uses the single revision property so that cannot happen again).

The ADVANCE_TIME game rule only exists on newer Minecraft versions. On older servers the field reference fails with a LinkageError (NoSuchFieldError, or ExceptionInInitializerError where the game rule registry cannot load), and that error previously escaped setAdvanceTime. All three implementations (core, spigot, paper) now catch it, log a single warning and skip the rule, so the plugin keeps working on those versions.

Also adds a unit test for the guard. It avoids Mockito on purpose: the pinned Mockito 4.10 predates the JDK the CI builds with, so the test uses a plain JDK proxy stub instead. Happy-path coverage comes from the Paper smoke test, which boots a real server with the built jar.